### PR TITLE
Tiknoff api v2 (from vitalets fork)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ lib
 dist
 .idea
 /.vscode
-.env
+.tokens.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 dist
 .idea
 /.vscode
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ node_modules
 .prettierrc.js
 rollup.config.js
 tsconfig.json
+.env

--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,4 @@ node_modules
 .prettierrc.js
 rollup.config.js
 tsconfig.json
-.env
+.tokens.json

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -125,7 +125,7 @@ export default {
     // runner: "jest-runner",
 
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    setupFiles: ['dotenv/config'],
+    // setupFiles: ['dotenv/config'],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
     // setupFilesAfterEnv: [],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -125,7 +125,7 @@ export default {
     // runner: "jest-runner",
 
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
+    setupFiles: ['dotenv/config'],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
     // setupFilesAfterEnv: [],
@@ -170,14 +170,11 @@ export default {
 
     // A map from regular expressions to paths to transformers
     transform: {
-        '.(ts|tsx)': 'ts-jest/preprocessor.js',
+        '.(ts|tsx)': 'ts-jest',
     },
 
     // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-    // transformIgnorePatterns: [
-    //   "/node_modules/",
-    //   "\\.pnp\\.[^\\/]+$"
-    // ],
+    transformIgnorePatterns: ['/node_modules/(?!tinkoff-invest-api/)', '\\.pnp\\.[^\\/]+$'],
 
     // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
     // unmockedModulePathPatterns: undefined,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -125,7 +125,7 @@ export default {
     // runner: "jest-runner",
 
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: ['dotenv/config'],
+    // setupFiles: [],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
     // setupFilesAfterEnv: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "@debut/community-core",
-    "version": "3.0.8",
+    "name": "@debut/enterprise-core",
+    "version": "3.0.21",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@debut/community-core",
-            "version": "3.0.8",
+            "name": "@debut/enterprise-core",
+            "version": "3.0.21",
             "license": "Apache-2.0",
             "dependencies": {
                 "@debut/plugin-utils": "^1.2.0",
@@ -16,7 +16,9 @@
                 "async-genetic": "^1.4.4",
                 "binance-api-node": "0.11.29",
                 "cli-progress": "^3.10.0",
-                "node-fetch": "^3.1.0"
+                "node-fetch": "^3.1.0",
+                "tinkoff-invest-api": "^1.1.1",
+                "tinkoff-sdk-grpc-js": "^0.1.2"
             },
             "bin": {
                 "finder": "lib/cli/finder.js",
@@ -41,18 +43,19 @@
                 "prettier": "^2.5.1",
                 "rollup": "^2.63.0",
                 "rollup-plugin-terser": "^7.0.2",
-                "rollup-plugin-typescript2": "^0.31.1",
-                "ts-jest": "^27.1.2",
-                "typescript": "^4.5.4"
+                "rollup-plugin-typescript2": "^0.31.0",
+                "ts-jest": "^27.0.7",
+                "ts-node": "^10.4.0",
+                "typescript": "^4.5.2"
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-            "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+            "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.16.0"
+                "@babel/highlight": "^7.14.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -659,6 +662,27 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "dev": true,
+            "dependencies": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@debut/plugin-utils": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@debut/plugin-utils/-/plugin-utils-1.2.0.tgz",
@@ -717,6 +741,36 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+            "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
+            "dependencies": {
+                "@grpc/proto-loader": "^0.6.4",
+                "@types/node": ">=12.12.47"
+            },
+            "engines": {
+                "node": "^8.13.0 || >=10.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.6.11",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.11.tgz",
+            "integrity": "sha512-MRiPjTjNgKxMupQ0M8mM9Mcljb2aZvE3Y/oEv+dacozIs2TwTdiPbvfkZpMeghfjGtoDJhDjyCtmFzJcjdDTUQ==",
+            "dependencies": {
+                "@types/long": "^4.0.1",
+                "lodash.camelcase": "^4.3.0",
+                "long": "^4.0.0 || ^5.2.0",
+                "protobufjs": "^6.10.0",
+                "yargs": "^16.2.0"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -1091,6 +1145,60 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
         "node_modules/@rollup/pluginutils": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -1117,9 +1225,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-            "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
+            "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
@@ -1172,6 +1280,30 @@
                 "@types/semver": "^7.3.9",
                 "ts-type": "^1.2.40"
             }
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+            "dev": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.1.18",
@@ -1284,6 +1416,11 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
             "dev": true
+        },
+        "node_modules/@types/long": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
         },
         "node_modules/@types/node": {
             "version": "17.0.8",
@@ -1629,6 +1766,14 @@
                 "node": ">=6.5"
             }
         },
+        "node_modules/abort-controller-x": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.6.tgz",
+            "integrity": "sha512-U8MmmcfIzl7qnzoog1woxKX/eYkQin3WR7k/S2dtpGLlSlsndXnvOYQEq8y1VnHC3+ofNFAT0GRgHq1lBbXlDQ==",
+            "dependencies": {
+                "node-abort-controller": "^1.2.1 || ^2.0.0"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -1756,7 +1901,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -1779,6 +1923,12 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -2129,7 +2279,6 @@
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
             "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -2156,7 +2305,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -2167,8 +2315,7 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/colorette": {
             "version": "1.2.2",
@@ -2222,9 +2369,9 @@
             }
         },
         "node_modules/cosmiconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-            "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
             "dev": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
@@ -2236,6 +2383,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -2356,6 +2509,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/diff-sequences": {
@@ -2479,7 +2641,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3179,7 +3340,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
@@ -3500,9 +3660,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -4591,9 +4751,9 @@
             }
         },
         "node_modules/lines-and-columns": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
         "node_modules/locate-path": {
@@ -4614,6 +4774,11 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4630,6 +4795,11 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz",
             "integrity": "sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg="
+        },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -4711,21 +4881,21 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+            "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "version": "2.1.33",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+            "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
             "dev": true,
             "dependencies": {
-                "mime-db": "1.51.0"
+                "mime-db": "1.50.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -4768,6 +4938,36 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
+        },
+        "node_modules/nice-grpc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-1.2.0.tgz",
+            "integrity": "sha512-M5B8FE7Y9nNgOnjpD2YS7oM+iuzTLy0srrFQtleXFyJ/VWzvqa++utr6kajRMF2XprFFVXllF7xvRVD7FCjXdg==",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.6.1",
+                "abort-controller-x": "^0.2.4",
+                "nice-grpc-common": "^1.1.0",
+                "node-abort-controller": "^1.2.1"
+            }
+        },
+        "node_modules/nice-grpc-common": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-1.1.0.tgz",
+            "integrity": "sha512-klxJ/lxMyH1KkT02woMBWL3A7BQSTH5jGodJIpNbbv7WKeFBWJaEtT6p7kZJBhGYXtSsQ+TyMU1EJR9BH14YfQ==",
+            "dependencies": {
+                "node-abort-controller": "^2.0.0",
+                "ts-error": "^1.0.6"
+            }
+        },
+        "node_modules/nice-grpc-common/node_modules/node-abort-controller": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
+            "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
+        },
+        "node_modules/node-abort-controller": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
+            "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ=="
         },
         "node_modules/node-fetch": {
             "version": "3.1.0",
@@ -5186,6 +5386,31 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/protobufjs": {
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": ">=13.7.0",
+                "long": "^4.0.0"
+            },
+            "bin": {
+                "pbjs": "bin/pbjs",
+                "pbts": "bin/pbts"
+            }
+        },
         "node_modules/psl": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -5257,7 +5482,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5469,9 +5693,9 @@
             "dev": true
         },
         "node_modules/semver-regex": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-            "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+            "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -5756,6 +5980,36 @@
             "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
             "dev": true
         },
+        "node_modules/tinkoff-invest-api": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinkoff-invest-api/-/tinkoff-invest-api-1.1.1.tgz",
+            "integrity": "sha512-QGqDUtjnyPu7GIw4zO2TlGov0lBLSqDfa9opCh1OoUjF022GXOoIRcs/6KZz6syj2TsrAIpo3CXlIwqIfKyuPw==",
+            "dependencies": {
+                "long": "^4.0.0",
+                "ms": "^3.0.0-beta.2",
+                "nice-grpc": "^1.1.1",
+                "protobufjs": "^6.11.2"
+            }
+        },
+        "node_modules/tinkoff-invest-api/node_modules/ms": {
+            "version": "3.0.0-canary.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+            "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+            "engines": {
+                "node": ">=12.13"
+            }
+        },
+        "node_modules/tinkoff-sdk-grpc-js": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tinkoff-sdk-grpc-js/-/tinkoff-sdk-grpc-js-0.1.2.tgz",
+            "integrity": "sha512-/lroelH8EdfKmLmSP+YOaXEs7CJRlAdxe9GmlSTdpb6pAc2GP3JHEe2yF/Hs84TzXq7d8ngx+6ky/NFjfPRQHQ==",
+            "dependencies": {
+                "@grpc/grpc-js": "^1.5.10",
+                "long": "^4.0.0",
+                "nice-grpc": "^1.1.0",
+                "protobufjs": "^6.11.2"
+            }
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5809,6 +6063,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ts-error": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+            "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="
+        },
         "node_modules/ts-jest": {
             "version": "27.1.2",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
@@ -5851,6 +6110,56 @@
                 "esbuild": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/ts-node": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+            "dev": true,
+            "dependencies": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ts-node/node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/ts-toolbelt": {
@@ -6166,7 +6475,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -6233,7 +6541,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -6257,7 +6564,6 @@
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
             "dependencies": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -6275,9 +6581,17 @@
             "version": "20.2.7",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
             "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
-            "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/yocto-queue": {
@@ -6295,12 +6609,12 @@
     },
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-            "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+            "version": "7.15.8",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
+            "integrity": "sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.16.0"
+                "@babel/highlight": "^7.14.5"
             }
         },
         "@babel/compat-data": {
@@ -6760,6 +7074,21 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "@cspotcode/source-map-consumer": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+            "dev": true
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-consumer": "0.8.0"
+            }
+        },
         "@debut/plugin-utils": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@debut/plugin-utils/-/plugin-utils-1.2.0.tgz",
@@ -6809,6 +7138,27 @@
                         "argparse": "^2.0.1"
                     }
                 }
+            }
+        },
+        "@grpc/grpc-js": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
+            "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
+            "requires": {
+                "@grpc/proto-loader": "^0.6.4",
+                "@types/node": ">=12.12.47"
+            }
+        },
+        "@grpc/proto-loader": {
+            "version": "0.6.11",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.11.tgz",
+            "integrity": "sha512-MRiPjTjNgKxMupQ0M8mM9Mcljb2aZvE3Y/oEv+dacozIs2TwTdiPbvfkZpMeghfjGtoDJhDjyCtmFzJcjdDTUQ==",
+            "requires": {
+                "@types/long": "^4.0.1",
+                "lodash.camelcase": "^4.3.0",
+                "long": "^4.0.0 || ^5.2.0",
+                "protobufjs": "^6.10.0",
+                "yargs": "^16.2.0"
             }
         },
         "@humanwhocodes/config-array": {
@@ -7105,6 +7455,60 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
         "@rollup/pluginutils": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -7125,9 +7529,9 @@
             }
         },
         "@sinonjs/fake-timers": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
-            "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.0.1.tgz",
+            "integrity": "sha512-AU7kwFxreVd6OAXcAFlKSmZquiRUU0FvYm44k1Y1QbK7Co4m0aqfGMhjykIeQp/H6rcl+nFmj0zfdUcGVs9Dew==",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
@@ -7173,6 +7577,30 @@
                 "@types/semver": "^7.3.9",
                 "ts-type": "^1.2.40"
             }
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+            "dev": true
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+            "dev": true
         },
         "@types/babel__core": {
             "version": "7.1.18",
@@ -7285,6 +7713,11 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
             "dev": true
+        },
+        "@types/long": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
         },
         "@types/node": {
             "version": "17.0.8",
@@ -7513,6 +7946,14 @@
                 "event-target-shim": "^5.0.0"
             }
         },
+        "abort-controller-x": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.6.tgz",
+            "integrity": "sha512-U8MmmcfIzl7qnzoog1woxKX/eYkQin3WR7k/S2dtpGLlSlsndXnvOYQEq8y1VnHC3+ofNFAT0GRgHq1lBbXlDQ==",
+            "requires": {
+                "node-abort-controller": "^1.2.1 || ^2.0.0"
+            }
+        },
         "acorn": {
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -7602,7 +8043,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "requires": {
                 "color-convert": "^2.0.1"
             }
@@ -7616,6 +8056,12 @@
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
             }
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
         },
         "argparse": {
             "version": "1.0.10",
@@ -7894,7 +8340,6 @@
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
             "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-            "dev": true,
             "requires": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
@@ -7917,7 +8362,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -7925,8 +8369,7 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "colorette": {
             "version": "1.2.2",
@@ -7977,9 +8420,9 @@
             }
         },
         "cosmiconfig": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-            "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+            "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
             "dev": true,
             "requires": {
                 "@types/parse-json": "^4.0.0",
@@ -7988,6 +8431,12 @@
                 "path-type": "^4.0.0",
                 "yaml": "^1.10.0"
             }
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -8081,6 +8530,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+            "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
         "diff-sequences": {
@@ -8180,8 +8635,7 @@
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-string-regexp": {
             "version": "4.0.0",
@@ -8698,8 +9152,7 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-intrinsic": {
             "version": "1.1.1",
@@ -8917,9 +9370,9 @@
             }
         },
         "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
             "dev": true
         },
         "import-fresh": {
@@ -9769,9 +10222,9 @@
             }
         },
         "lines-and-columns": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
         "locate-path": {
@@ -9789,6 +10242,11 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9805,6 +10263,11 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz",
             "integrity": "sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg="
+        },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
         },
         "lru-cache": {
             "version": "6.0.0",
@@ -9870,18 +10333,18 @@
             }
         },
         "mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.50.0.tgz",
+            "integrity": "sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+            "version": "2.1.33",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.33.tgz",
+            "integrity": "sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==",
             "dev": true,
             "requires": {
-                "mime-db": "1.51.0"
+                "mime-db": "1.50.0"
             }
         },
         "mimic-fn": {
@@ -9915,6 +10378,38 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
+        },
+        "nice-grpc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-1.2.0.tgz",
+            "integrity": "sha512-M5B8FE7Y9nNgOnjpD2YS7oM+iuzTLy0srrFQtleXFyJ/VWzvqa++utr6kajRMF2XprFFVXllF7xvRVD7FCjXdg==",
+            "requires": {
+                "@grpc/grpc-js": "^1.6.1",
+                "abort-controller-x": "^0.2.4",
+                "nice-grpc-common": "^1.1.0",
+                "node-abort-controller": "^1.2.1"
+            }
+        },
+        "nice-grpc-common": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-1.1.0.tgz",
+            "integrity": "sha512-klxJ/lxMyH1KkT02woMBWL3A7BQSTH5jGodJIpNbbv7WKeFBWJaEtT6p7kZJBhGYXtSsQ+TyMU1EJR9BH14YfQ==",
+            "requires": {
+                "node-abort-controller": "^2.0.0",
+                "ts-error": "^1.0.6"
+            },
+            "dependencies": {
+                "node-abort-controller": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
+                    "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
+                }
+            }
+        },
+        "node-abort-controller": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
+            "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ=="
         },
         "node-fetch": {
             "version": "3.1.0",
@@ -10228,6 +10723,26 @@
                 "sisteransi": "^1.0.5"
             }
         },
+        "protobufjs": {
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": ">=13.7.0",
+                "long": "^4.0.0"
+            }
+        },
         "psl": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -10275,8 +10790,7 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "resolve": {
             "version": "1.20.0",
@@ -10425,9 +10939,9 @@
             "dev": true
         },
         "semver-regex": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-            "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+            "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
             "dev": true
         },
         "serialize-javascript": {
@@ -10644,6 +11158,35 @@
             "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
             "dev": true
         },
+        "tinkoff-invest-api": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinkoff-invest-api/-/tinkoff-invest-api-1.1.1.tgz",
+            "integrity": "sha512-QGqDUtjnyPu7GIw4zO2TlGov0lBLSqDfa9opCh1OoUjF022GXOoIRcs/6KZz6syj2TsrAIpo3CXlIwqIfKyuPw==",
+            "requires": {
+                "long": "^4.0.0",
+                "ms": "^3.0.0-beta.2",
+                "nice-grpc": "^1.1.1",
+                "protobufjs": "^6.11.2"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "3.0.0-canary.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+                    "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
+                }
+            }
+        },
+        "tinkoff-sdk-grpc-js": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tinkoff-sdk-grpc-js/-/tinkoff-sdk-grpc-js-0.1.2.tgz",
+            "integrity": "sha512-/lroelH8EdfKmLmSP+YOaXEs7CJRlAdxe9GmlSTdpb6pAc2GP3JHEe2yF/Hs84TzXq7d8ngx+6ky/NFjfPRQHQ==",
+            "requires": {
+                "@grpc/grpc-js": "^1.5.10",
+                "long": "^4.0.0",
+                "nice-grpc": "^1.1.0",
+                "protobufjs": "^6.11.2"
+            }
+        },
         "tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -10685,6 +11228,11 @@
                 "punycode": "^2.1.1"
             }
         },
+        "ts-error": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+            "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="
+        },
         "ts-jest": {
             "version": "27.1.2",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
@@ -10699,6 +11247,34 @@
                 "make-error": "1.x",
                 "semver": "7.x",
                 "yargs-parser": "20.x"
+            }
+        },
+        "ts-node": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "0.7.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "yn": "3.1.1"
+            },
+            "dependencies": {
+                "acorn-walk": {
+                    "version": "8.2.0",
+                    "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+                    "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+                    "dev": true
+                }
             }
         },
         "ts-toolbelt": {
@@ -10958,7 +11534,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -11004,8 +11579,7 @@
         "y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yallist": {
             "version": "4.0.0",
@@ -11023,7 +11597,6 @@
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-            "dev": true,
             "requires": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -11037,7 +11610,12 @@
         "yargs-parser": {
             "version": "20.2.7",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-            "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+            "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
             "dev": true
         },
         "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
                 "@typescript-eslint/eslint-plugin": "^5.9.1",
                 "@typescript-eslint/parser": "^5.9.1",
                 "benchmark": "^2.1.4",
-                "dotenv": "^16.0.1",
                 "eslint": "^8.6.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-prettier": "^4.0.0",
@@ -2543,15 +2542,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/dotenv": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-            "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/electron-to-chromium": {
@@ -8534,12 +8524,6 @@
                     "dev": true
                 }
             }
-        },
-        "dotenv": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-            "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-            "dev": true
         },
         "electron-to-chromium": {
             "version": "1.3.769",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,12 @@
             "dependencies": {
                 "@debut/plugin-utils": "^1.2.0",
                 "@master-chief/alpaca": "^6.3.11",
-                "@tinkoff/invest-openapi-js-sdk": "^1.5.0",
                 "@types/ws": "^8.2.2",
                 "async-genetic": "^1.4.4",
                 "binance-api-node": "0.11.29",
                 "cli-progress": "^3.10.0",
                 "node-fetch": "^3.1.0",
-                "tinkoff-invest-api": "^1.1.1",
+                "tinkoff-invest-api": "^3.1.0",
                 "tinkoff-sdk-grpc-js": "^0.1.2"
             },
             "bin": {
@@ -34,6 +33,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.9.1",
                 "@typescript-eslint/parser": "^5.9.1",
                 "benchmark": "^2.1.4",
+                "dotenv": "^16.0.1",
                 "eslint": "^8.6.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-prettier": "^4.0.0",
@@ -1233,35 +1233,6 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "node_modules/@tinkoff/invest-openapi-js-sdk": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@tinkoff/invest-openapi-js-sdk/-/invest-openapi-js-sdk-1.5.0.tgz",
-            "integrity": "sha512-jVWkDTA8yaqTnFkq+Ty1lGW9uVauwP4lXn7f0QeDNVWZ3fqAo+qDYt+mG8VEqkauQJ8kvRsF5uvoyWoTcLG9ZQ==",
-            "dependencies": {
-                "isomorphic-fetch": "^3.0.0",
-                "ws": "^7.3.0"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/@tinkoff/invest-openapi-js-sdk/node_modules/isomorphic-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-            "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-            "dependencies": {
-                "node-fetch": "^2.6.1",
-                "whatwg-fetch": "^3.4.1"
-            }
-        },
-        "node_modules/@tinkoff/invest-openapi-js-sdk/node_modules/node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            }
-        },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2451,9 +2422,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2572,6 +2543,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+            "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/electron-to-chromium": {
@@ -5387,9 +5367,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+            "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
             "hasInstallScript": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
@@ -5981,14 +5961,15 @@
             "dev": true
         },
         "node_modules/tinkoff-invest-api": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinkoff-invest-api/-/tinkoff-invest-api-1.1.1.tgz",
-            "integrity": "sha512-QGqDUtjnyPu7GIw4zO2TlGov0lBLSqDfa9opCh1OoUjF022GXOoIRcs/6KZz6syj2TsrAIpo3CXlIwqIfKyuPw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinkoff-invest-api/-/tinkoff-invest-api-3.1.0.tgz",
+            "integrity": "sha512-ET7GB9+yL3MIPGCUeZPEr1Ym492QYHA9YOWLRhmUC3uiRr0k8NY9BVnXntIYgKLhCx9QAMrJV59VoyG1esq+sA==",
             "dependencies": {
+                "debug": "^4.3.4",
                 "long": "^4.0.0",
                 "ms": "^3.0.0-beta.2",
-                "nice-grpc": "^1.1.1",
-                "protobufjs": "^6.11.2"
+                "nice-grpc": "^1.2.0",
+                "protobufjs": "^6.11.3"
             }
         },
         "node_modules/tinkoff-invest-api/node_modules/ms": {
@@ -7537,31 +7518,6 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
-        "@tinkoff/invest-openapi-js-sdk": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@tinkoff/invest-openapi-js-sdk/-/invest-openapi-js-sdk-1.5.0.tgz",
-            "integrity": "sha512-jVWkDTA8yaqTnFkq+Ty1lGW9uVauwP4lXn7f0QeDNVWZ3fqAo+qDYt+mG8VEqkauQJ8kvRsF5uvoyWoTcLG9ZQ==",
-            "requires": {
-                "isomorphic-fetch": "^3.0.0",
-                "ws": "^7.3.0"
-            },
-            "dependencies": {
-                "isomorphic-fetch": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-                    "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-                    "requires": {
-                        "node-fetch": "^2.6.1",
-                        "whatwg-fetch": "^3.4.1"
-                    }
-                },
-                "node-fetch": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-                }
-            }
-        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -8489,9 +8445,9 @@
             }
         },
         "debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
             }
@@ -8578,6 +8534,12 @@
                     "dev": true
                 }
             }
+        },
+        "dotenv": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+            "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+            "dev": true
         },
         "electron-to-chromium": {
             "version": "1.3.769",
@@ -10724,9 +10686,9 @@
             }
         },
         "protobufjs": {
-            "version": "6.11.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "version": "6.11.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+            "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -11159,14 +11121,15 @@
             "dev": true
         },
         "tinkoff-invest-api": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/tinkoff-invest-api/-/tinkoff-invest-api-1.1.1.tgz",
-            "integrity": "sha512-QGqDUtjnyPu7GIw4zO2TlGov0lBLSqDfa9opCh1OoUjF022GXOoIRcs/6KZz6syj2TsrAIpo3CXlIwqIfKyuPw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinkoff-invest-api/-/tinkoff-invest-api-3.1.0.tgz",
+            "integrity": "sha512-ET7GB9+yL3MIPGCUeZPEr1Ym492QYHA9YOWLRhmUC3uiRr0k8NY9BVnXntIYgKLhCx9QAMrJV59VoyG1esq+sA==",
             "requires": {
+                "debug": "^4.3.4",
                 "long": "^4.0.0",
                 "ms": "^3.0.0-beta.2",
-                "nice-grpc": "^1.1.1",
-                "protobufjs": "^6.11.2"
+                "nice-grpc": "^1.2.0",
+                "protobufjs": "^6.11.3"
             },
             "dependencies": {
                 "ms": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "binance-api-node": "0.11.29",
         "cli-progress": "^3.10.0",
         "node-fetch": "^3.1.0",
+        "tinkoff-invest-api": "^3.1.0",
         "tinkoff-sdk-grpc-js": "^0.1.2"
     },
     "devDependencies": {
@@ -44,6 +45,7 @@
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
         "benchmark": "^2.1.4",
+        "dotenv": "^16.0.1",
         "eslint": "^8.6.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "@typescript-eslint/eslint-plugin": "^5.9.1",
         "@typescript-eslint/parser": "^5.9.1",
         "benchmark": "^2.1.4",
-        "dotenv": "^16.0.1",
         "eslint": "^8.6.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "@debut/community-core",
-    "version": "3.0.8",
+    "name": "@debut/enterprise-core",
     "publishConfig": {
-        "access": "public"
+        "access": "restricted"
     },
+    "version": "3.0.21",
     "description": "Javascript Multibroker Trading System",
     "main": "lib/index.js",
     "module": "lib/index.js",
@@ -28,12 +28,12 @@
     "dependencies": {
         "@debut/plugin-utils": "^1.2.0",
         "@master-chief/alpaca": "^6.3.11",
-        "@tinkoff/invest-openapi-js-sdk": "^1.5.0",
         "@types/ws": "^8.2.2",
         "async-genetic": "^1.4.4",
         "binance-api-node": "0.11.29",
         "cli-progress": "^3.10.0",
-        "node-fetch": "^3.1.0"
+        "node-fetch": "^3.1.0",
+        "tinkoff-sdk-grpc-js": "^0.1.2"
     },
     "devDependencies": {
         "@debut/types": "^3.0.4",
@@ -53,9 +53,10 @@
         "prettier": "^2.5.1",
         "rollup": "^2.63.0",
         "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-typescript2": "^0.31.1",
-        "ts-jest": "^27.1.2",
-        "typescript": "^4.5.4"
+        "rollup-plugin-typescript2": "^0.31.0",
+        "ts-jest": "^27.0.7",
+        "ts-node": "^10.4.0",
+        "typescript": "^4.5.2"
     },
     "husky": {
         "hooks": {

--- a/src/cli/tester/history-providers/__tests__/tinkoff.test.ts
+++ b/src/cli/tester/history-providers/__tests__/tinkoff.test.ts
@@ -1,0 +1,10 @@
+import { requestTinkoff } from '../tinkoff';
+
+test('requestTinkoff', async () => {
+    const from = new Date('2022-06-08T07:00:00.000Z').getTime();
+    const to = new Date('2022-06-08T07:10:00.000Z').getTime();
+    const candles = await requestTinkoff(from, to, 'SBER', '1min');
+    expect(candles).toHaveLength(10);
+    expect(new Date(candles[0].time).toISOString()).toEqual('2022-06-08T07:00:00.000Z');
+    expect(new Date(candles.slice(-1)[0].time).toISOString()).toEqual('2022-06-08T07:09:00.000Z');
+});

--- a/src/transports/__tests__/tinkoff.v2.test.ts
+++ b/src/transports/__tests__/tinkoff.v2.test.ts
@@ -1,0 +1,94 @@
+import { TinkoffTransport } from '../tinkoff.v2';
+
+function createTransport() {
+    return new TinkoffTransportTest(process.env.TINKOFF_API_TOKEN);
+}
+
+class TinkoffTransportTest extends TinkoffTransport {
+    getApi() {
+        return this.api;
+    }
+}
+
+test('constructor: empty token', async () => {
+    const fn = () => new TinkoffTransport('');
+    expect(fn).toThrow('token is incorrect');
+});
+
+test('getInstrument', async () => {
+    const transport = createTransport();
+    const instrument = await transport.getInstrument({
+        broker: 'tinkoff',
+        ticker: 'UBER',
+        currency: 'usd',
+        interval: '5min',
+        amount: 1,
+    });
+    expect(instrument).toEqual({
+        figi: 'BBG002B04MT8',
+        ticker: 'UBER',
+        id: 'UBER:undefined',
+        lot: 1,
+        lotPrecision: 1,
+        minNotional: 0,
+        minQuantity: 1,
+        type: 'SPOT',
+    });
+});
+
+test('prepareLots', () => {
+    const transport = createTransport();
+    const lots = transport.prepareLots(2.1);
+    expect(lots).toEqual(2);
+});
+
+// test pass only when moex works
+test('subscribeToTick', async () => {
+    const transport = createTransport();
+    try {
+        let resolve;
+        const promise = new Promise((_) => (resolve = _));
+        const unsubscribe = await transport.subscribeToTick(
+            {
+                broker: 'tinkoff',
+                ticker: 'SBER',
+                currency: 'rub',
+                interval: '1min',
+                amount: 1,
+            },
+            resolve,
+        );
+        const data = await promise;
+        unsubscribe();
+        expect(data).toHaveProperty('c');
+        expect(data).toHaveProperty('time');
+    } finally {
+        transport.getApi().stream.market.cancel();
+    }
+});
+
+test('subscribeOrderBook', async () => {
+    const transport = createTransport();
+    try {
+        let resolve;
+        const promise = new Promise((_) => (resolve = _));
+        const unsubscribe = await transport.subscribeOrderBook(
+            {
+                broker: 'tinkoff',
+                ticker: 'SBER',
+                currency: 'rub',
+                interval: '1min',
+                amount: 1,
+            },
+            resolve,
+        );
+        const data = await promise;
+        unsubscribe();
+        expect(data).toHaveProperty('bids');
+        expect(data).toHaveProperty('asks');
+    } finally {
+        transport.getApi().stream.market.cancel();
+    }
+});
+
+test.skip('placeOrder', async () => {});

--- a/src/transports/__tests__/tinkoff.v2.test.ts
+++ b/src/transports/__tests__/tinkoff.v2.test.ts
@@ -1,7 +1,10 @@
+import { cli } from '@debut/plugin-utils';
 import { TinkoffTransport } from '../tinkoff.v2';
 
+const { tinkoff, tinkoffAccountId } = cli.getTokens();
+
 function createTransport() {
-    return new TinkoffTransportTest(process.env.TINKOFF_API_TOKEN);
+    return new TinkoffTransportTest(tinkoff, tinkoffAccountId);
 }
 
 class TinkoffTransportTest extends TinkoffTransport {
@@ -10,9 +13,9 @@ class TinkoffTransportTest extends TinkoffTransport {
     }
 }
 
-test('constructor: empty token', async () => {
-    const fn = () => new TinkoffTransport('');
-    expect(fn).toThrow('token is incorrect');
+test('constructor: empty token/accountId', async () => {
+    expect(() => new TinkoffTransport('', '123')).toThrow('token is incorrect');
+    expect(() => new TinkoffTransport('123', '')).toThrow('accountId is empty');
 });
 
 test('getInstrument', async () => {
@@ -23,11 +26,12 @@ test('getInstrument', async () => {
         currency: 'usd',
         interval: '5min',
         amount: 1,
+        instrumentType: 'SPOT',
     });
     expect(instrument).toEqual({
         figi: 'BBG002B04MT8',
         ticker: 'UBER',
-        id: 'UBER:undefined',
+        id: 'UBER:SPOT',
         lot: 1,
         lotPrecision: 1,
         minNotional: 0,
@@ -55,6 +59,7 @@ test('subscribeToTick', async () => {
                 currency: 'rub',
                 interval: '1min',
                 amount: 1,
+                instrumentType: 'SPOT',
             },
             resolve,
         );
@@ -79,6 +84,7 @@ test('subscribeOrderBook', async () => {
                 currency: 'rub',
                 interval: '1min',
                 amount: 1,
+                instrumentType: 'SPOT',
             },
             resolve,
         );

--- a/src/transports/binance.ts
+++ b/src/transports/binance.ts
@@ -61,6 +61,7 @@ import { Transaction } from './utils/transaction';
  */
 
 const badStatus = ['CANCELED', 'EXPIRED', 'PENDING_CANCEL', 'REJECTED'];
+const ignoredErrorsList = ['Margin is insufficient', 'ReduceOnly Order is rejected'];
 export class BinanceTransport implements BaseTransport {
     public api: ReturnType<typeof Binance>;
     protected instruments: Map<string, Instrument> = new Map();
@@ -371,8 +372,10 @@ export class BinanceTransport implements BaseTransport {
     }
 
     private canRetry(e: Error) {
-        if (e.message.includes('ReduceOnly Order is rejected')) {
-            return false;
+        for (const ignoreText of ignoredErrorsList) {
+            if (e.message.includes(ignoreText)) {
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
Сделал отдельный ПР с Tinkoff API v2 из своего форка.

* пока перевел на api v2 только `transports/tinkoff.v2.ts` (там вопросики в коде). `transports/tinkoff.ts` оставил для референса.
* добавил тесты